### PR TITLE
Refactored TextArea

### DIFF
--- a/src/trigger/text_area.cpp
+++ b/src/trigger/text_area.cpp
@@ -26,18 +26,16 @@
 
 TextArea::TextArea(const ReaderMapping& mapping) :
   TriggerBase(mapping),
-  m_started(false),
-  m_inside(false),
   m_once(false),
-  m_finished(false),
   m_items(),
   m_delay(4.0f),
   m_fade_delay(1.0f),
-  m_text_id(0),
-  m_update_timer(),
-  m_fade_timer()
+  m_current_text(0),
+  m_status(Status::NOT_STARTED),
+  m_timer()
 {
   float w, h;
+
   mapping.get("x", m_col.m_bbox.get_left(), 0.0f);
   mapping.get("y", m_col.m_bbox.get_top(), 0.0f);
   mapping.get("width", w, 32.0f);
@@ -46,29 +44,27 @@ TextArea::TextArea(const ReaderMapping& mapping) :
   mapping.get("delay", m_delay);
   mapping.get("once", m_once);
   mapping.get("fade-delay", m_fade_delay);
+
   m_col.m_bbox.set_size(w, h);
 }
 
 TextArea::TextArea(const Vector& pos) :
-  m_started(false),
-  m_inside(false),
   m_once(false),
-  m_finished(false),
   m_items(),
   m_delay(4.0f),
   m_fade_delay(1.0f),
-  m_text_id(0),
-  m_update_timer(),
-  m_fade_timer()
+  m_current_text(0),
+  m_status(Status::NOT_STARTED),
+  m_timer()
 {
   m_col.m_bbox.set_pos(pos);
-  m_col.m_bbox.set_size(32,32);
+  m_col.m_bbox.set_size(32, 32);
 }
 
 void
 TextArea::draw(DrawingContext& context)
 {
-  if(Editor::is_active())
+  if (Editor::is_active())
     context.color().draw_filled_rect(m_col.m_bbox, Color(1.0f, 1.0f, 1.0f, 0.6f), LAYER_OBJECTS);
 }
 
@@ -77,20 +73,27 @@ TextArea::event(Player& player, EventType type)
 {
   switch (type)
   {
-  case EVENT_TOUCH:
-    if (!m_started && !m_fade_timer.started() && m_items.size() > 0 && !m_inside && (!m_once || !m_finished))
-    {
-      m_update_timer.start(m_delay + m_fade_delay * 2, true);
-      m_started = true;
-      m_text_id = 0;
-    }
-    m_inside = true;
-    break;
-  case EVENT_LOSETOUCH:
-    m_inside = false;
-    break;
-  default:
-    break;
+    case EVENT_TOUCH:
+      if (m_status == Status::NOT_STARTED)
+      {
+        if (m_items.size() < 1)
+        {
+          log_warning << "Attempt to run a TextArea with no text, aborting" << std::endl;
+          return;
+        }
+
+        TextObject& text_object = Sector::get().get_singleton_by_type<TextObject>();
+
+        m_current_text = 0;
+        m_status = Status::FADING_IN;
+        m_timer.start(m_fade_delay);
+        text_object.set_text(m_items[m_current_text]);
+        text_object.fade_in(m_fade_delay);
+      }
+      break;
+
+    default:
+      break;
   }
 }
 
@@ -98,28 +101,42 @@ void
 TextArea::update(float dt_sec)
 {
   TriggerBase::update(dt_sec);
-  if (m_started)
+
+  if (m_timer.check())
   {
     TextObject& text_object = Sector::get().get_singleton_by_type<TextObject>();
-    if (m_text_id < m_items.size() && (m_update_timer.check() || m_text_id == 0) && !m_fade_timer.started())
+
+    switch(m_status)
     {
-      m_fade_timer.start(m_delay + m_fade_delay);
-      text_object.set_text(m_items[m_text_id]);
-      text_object.fade_in(m_fade_delay);
-      m_text_id++;
+      case Status::FADING_IN:
+        m_status = Status::WAITING;
+        m_timer.start(m_delay);
+        break;
+
+      case Status::WAITING:
+        m_status = Status::FADING_OUT;
+        m_timer.start(m_fade_delay);
+        text_object.fade_out(m_fade_delay);
+        break;
+
+      case Status::FADING_OUT:
+        if (++m_current_text >= m_items.size())
+        {
+          m_current_text = 0;
+          m_status = m_once ? Status::FINISHED : Status::NOT_STARTED;
+        }
+        else
+        {
+          m_status = Status::FADING_IN;
+          m_timer.start(m_fade_delay);
+          text_object.set_text(m_items[m_current_text]);
+          text_object.fade_in(m_fade_delay);
+        }
+        break;
+
+      default:
+        break;
     }
-    else if (m_text_id >= m_items.size())
-    {
-      m_started = false;
-      m_update_timer.stop();
-      m_fade_timer.start(m_delay + m_fade_delay);
-      m_finished = true;
-    }
-  }
-  if (m_fade_timer.check())
-  {
-    Sector::get().get_singleton_by_type<TextObject>().fade_out(m_fade_delay);
-    m_fade_timer.stop();
   }
 }
 
@@ -127,10 +144,13 @@ ObjectSettings
 TextArea::get_settings()
 {
   ObjectSettings settings = TriggerBase::get_settings();
+
   settings.add_bool(_("Once"), &m_once, "once");
   settings.add_float(_("Text change time"), &m_delay, "delay");
   settings.add_float(_("Fade time"), &m_fade_delay, "fade-delay");
   settings.add_string_array(_("Texts"), "texts", m_items);
+
   return settings;
 }
+
 /* EOF */

--- a/src/trigger/text_area.hpp
+++ b/src/trigger/text_area.hpp
@@ -22,6 +22,16 @@
 
 class TextArea final : public TriggerBase
 {
+private:
+  enum class Status
+  {
+    NOT_STARTED,
+    FADING_IN,
+    WAITING,
+    FADING_OUT,
+    FINISHED
+  };
+
 public:
   TextArea(const ReaderMapping& mapping);
   TextArea(const Vector& pos);
@@ -34,12 +44,16 @@ public:
   virtual std::string get_class() const override { return "text-area"; }
   virtual std::string get_display_name() const override { return _("Text Area"); }
   virtual bool has_variable_size() const override { return true; }
+
 private:
-  bool m_started, m_inside, m_once, m_finished;
+  bool m_once;
   std::vector<std::string> m_items;
-  float m_delay, m_fade_delay;
-  unsigned int m_text_id;
-  Timer m_update_timer, m_fade_timer;
+  float m_delay;
+  float m_fade_delay;
+  size_t m_current_text;
+  Status m_status;
+  Timer m_timer;
+
 private:
   TextArea(const TextArea&) = delete;
   TextArea& operator=(const TextArea&) = delete;


### PR DESCRIPTION
- Adds a Status object, to have a consistent and reliable way of checking the TextArea's progression
- Removes three redundant booleans:
  - m_started can be checked with the state
  - m_inside is not needed because the player cannot re-enter the zone without leaving it first (and in any case, if the game bugs and fails to detect Tux leaving the zone, it should work anyways when it re-enters the zone again)
  - m_finished was redundant with m_started and, like it, was superseded by the status enum
- Condenses two timers into one, since only one needs to be running at a time
- Improves general code quality (Spacing, variable names, etc.)